### PR TITLE
feature/campaign: create campaign table with relations and CRUD operation

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -6,6 +6,8 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { UserModule } from './user/user.module';
 import { User } from './user/entities/user.entity';
 import { AuthModule } from './auth/auth.module';
+import { CampaignModule } from './campaign/campaign.module';
+import { Campaign } from './campaign/entities/campaign.entity';
 
 @Module({
   imports: [ConfigModule.forRoot(), TypeOrmModule.forRoot({
@@ -16,8 +18,8 @@ import { AuthModule } from './auth/auth.module';
     password: process.env.DB_PASSWORD,
     database: process.env.DB_DATABASE,
     synchronize: true,
-    entities: [User]
-  }), UserModule, AuthModule],
+    entities: [User, Campaign]
+  }), UserModule, AuthModule, CampaignModule],
   controllers: [AppController],
   providers: [AppService],
 })

--- a/src/campaign/campaign.controller.spec.ts
+++ b/src/campaign/campaign.controller.spec.ts
@@ -1,0 +1,20 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { CampaignController } from './campaign.controller';
+import { CampaignService } from './campaign.service';
+
+describe('CampaignController', () => {
+  let controller: CampaignController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [CampaignController],
+      providers: [CampaignService],
+    }).compile();
+
+    controller = module.get<CampaignController>(CampaignController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/src/campaign/campaign.controller.ts
+++ b/src/campaign/campaign.controller.ts
@@ -1,0 +1,34 @@
+import { Controller, Get, Post, Body, Patch, Param, Delete } from '@nestjs/common';
+import { CampaignService } from './campaign.service';
+import { CreateCampaignDto } from './dto/create-campaign.dto';
+import { UpdateCampaignDto } from './dto/update-campaign.dto';
+
+@Controller('campaign')
+export class CampaignController {
+  constructor(private readonly campaignService: CampaignService) {}
+
+  @Post()
+  create(@Body() createCampaignDto: CreateCampaignDto) {
+    return this.campaignService.create(createCampaignDto);
+  }
+
+  @Get()
+  findAll() {
+    return this.campaignService.findAll();
+  }
+
+  @Get(':id')
+  findOne(@Param('id') id: string) {
+    return this.campaignService.findOne(+id);
+  }
+
+  @Patch(':id')
+  update(@Param('id') id: string, @Body() updateCampaignDto: UpdateCampaignDto) {
+    return this.campaignService.update(+id, updateCampaignDto);
+  }
+
+  @Delete(':id')
+  remove(@Param('id') id: string) {
+    return this.campaignService.remove(+id);
+  }
+}

--- a/src/campaign/campaign.module.ts
+++ b/src/campaign/campaign.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { CampaignService } from './campaign.service';
+import { CampaignController } from './campaign.controller';
+
+@Module({
+  controllers: [CampaignController],
+  providers: [CampaignService],
+})
+export class CampaignModule {}

--- a/src/campaign/campaign.module.ts
+++ b/src/campaign/campaign.module.ts
@@ -1,9 +1,13 @@
 import { Module } from '@nestjs/common';
 import { CampaignService } from './campaign.service';
 import { CampaignController } from './campaign.controller';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Campaign } from './entities/campaign.entity';
+import { User } from 'src/user/entities/user.entity';
 
 @Module({
+  imports: [TypeOrmModule.forFeature([Campaign, User])],
   controllers: [CampaignController],
   providers: [CampaignService],
 })
-export class CampaignModule {}
+export class CampaignModule { }

--- a/src/campaign/campaign.service.spec.ts
+++ b/src/campaign/campaign.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { CampaignService } from './campaign.service';
+
+describe('CampaignService', () => {
+  let service: CampaignService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [CampaignService],
+    }).compile();
+
+    service = module.get<CampaignService>(CampaignService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/src/campaign/campaign.service.ts
+++ b/src/campaign/campaign.service.ts
@@ -1,0 +1,26 @@
+import { Injectable } from '@nestjs/common';
+import { CreateCampaignDto } from './dto/create-campaign.dto';
+import { UpdateCampaignDto } from './dto/update-campaign.dto';
+
+@Injectable()
+export class CampaignService {
+  create(createCampaignDto: CreateCampaignDto) {
+    return 'This action adds a new campaign';
+  }
+
+  findAll() {
+    return `This action returns all campaign`;
+  }
+
+  findOne(id: number) {
+    return `This action returns a #${id} campaign`;
+  }
+
+  update(id: number, updateCampaignDto: UpdateCampaignDto) {
+    return `This action updates a #${id} campaign`;
+  }
+
+  remove(id: number) {
+    return `This action removes a #${id} campaign`;
+  }
+}

--- a/src/campaign/campaign.service.ts
+++ b/src/campaign/campaign.service.ts
@@ -26,12 +26,16 @@ export class CampaignService {
     return this.campaignRepository.save(campaignData);
   }
 
-  findAll() {
-    return `This action returns all campaign`;
+  async findAll(): Promise<Campaign[]> {
+    return this.campaignRepository.find({ relations: ['user'] });
   }
 
-  findOne(id: number) {
-    return `This action returns a #${id} campaign`;
+  async findOne(campaign_id: number): Promise<Campaign> {
+    const campaignAvailable = await this.campaignRepository.findOne({ where: { campaign_id } })
+    if (!campaignAvailable) {
+      throw new NotFoundException("campaign not found");
+    }
+    return campaignAvailable;
   }
 
   update(id: number, updateCampaignDto: UpdateCampaignDto) {

--- a/src/campaign/campaign.service.ts
+++ b/src/campaign/campaign.service.ts
@@ -1,11 +1,29 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, NotFoundException } from '@nestjs/common';
 import { CreateCampaignDto } from './dto/create-campaign.dto';
 import { UpdateCampaignDto } from './dto/update-campaign.dto';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Campaign } from './entities/campaign.entity';
+import { Repository } from 'typeorm';
+import { User } from 'src/user/entities/user.entity';
 
 @Injectable()
 export class CampaignService {
-  create(createCampaignDto: CreateCampaignDto) {
-    return 'This action adds a new campaign';
+  constructor(
+    @InjectRepository(Campaign)
+    private campaignRepository: Repository<Campaign>,
+    @InjectRepository(User)
+    private readonly userRepository: Repository<User>
+  ) { }
+  async create(createCampaignDto: CreateCampaignDto): Promise<Campaign> {
+    const user = await this.userRepository.findOne({ where: { user_id: createCampaignDto.user_id } });
+    if (!user) {
+      throw new NotFoundException("user not found");
+    }
+    const campaignData = await this.campaignRepository.create({
+      ...createCampaignDto,
+      user: user
+    });
+    return this.campaignRepository.save(campaignData);
   }
 
   findAll() {

--- a/src/campaign/campaign.service.ts
+++ b/src/campaign/campaign.service.ts
@@ -45,6 +45,7 @@ export class CampaignService {
     }
 
     const campaignAvailable = await this.campaignRepository.findOne({ where: { campaign_id } })
+    // console.log("id:", campaign_id);
     if (!campaignAvailable) {
       throw new NotFoundException("campaign not found");
     }

--- a/src/campaign/campaign.service.ts
+++ b/src/campaign/campaign.service.ts
@@ -38,11 +38,31 @@ export class CampaignService {
     return campaignAvailable;
   }
 
-  update(id: number, updateCampaignDto: UpdateCampaignDto) {
-    return `This action updates a #${id} campaign`;
+  async update(campaign_id: number, updateCampaignDto: UpdateCampaignDto): Promise<Campaign> {
+    const userAvailable = await this.userRepository.findOne({ where: { user_id: updateCampaignDto.user_id } });
+    if (!userAvailable) {
+      throw new NotFoundException("user not found");
+    }
+
+    const campaignAvailable = await this.campaignRepository.findOne({ where: { campaign_id } })
+    if (!campaignAvailable) {
+      throw new NotFoundException("campaign not found");
+    }
+
+    const updatedCampaignData = await this.campaignRepository.create({
+      user: userAvailable,
+      ...campaignAvailable,
+      ...updateCampaignDto
+    })
+
+    return this.campaignRepository.save(updatedCampaignData);
   }
 
-  remove(id: number) {
-    return `This action removes a #${id} campaign`;
+  async remove(campaign_id: number): Promise<void> {
+    const campaignAvailable = await this.campaignRepository.findOne({ where: { campaign_id } })
+    if (!campaignAvailable) {
+      throw new NotFoundException("campaign not found");
+    }
+    await this.campaignRepository.remove(campaignAvailable);
   }
 }

--- a/src/campaign/dto/campaignStatus.ts
+++ b/src/campaign/dto/campaignStatus.ts
@@ -1,0 +1,5 @@
+export enum campaignStatus {
+    OPEN = 'open',
+    UPCOMING = 'upcoming',
+    CLOSED = 'closed'
+}

--- a/src/campaign/dto/create-campaign.dto.ts
+++ b/src/campaign/dto/create-campaign.dto.ts
@@ -13,7 +13,7 @@ export class CreateCampaignDto {
     campaignDescription: string
 
     @IsInt()
-    targetAmount: BigInt
+    targetAmount: number
 
     @IsDateString()
     start_date: Date

--- a/src/campaign/dto/create-campaign.dto.ts
+++ b/src/campaign/dto/create-campaign.dto.ts
@@ -1,0 +1,27 @@
+import { IsDateString, IsEnum, IsInt, IsString } from "class-validator";
+import { campaignStatus } from "./campaignStatus";
+
+
+export class CreateCampaignDto {
+    @IsInt()
+    user_id: number
+
+    @IsString()
+    campaignTitle: string
+
+    @IsString()
+    campaignDescription: string
+
+    @IsInt()
+    targetAmount: BigInt
+
+    @IsDateString()
+    start_date: Date
+
+    @IsDateString()
+    end_date: Date
+
+    @IsEnum({ campaignStatus })
+    status: campaignStatus
+
+}

--- a/src/campaign/dto/update-campaign.dto.ts
+++ b/src/campaign/dto/update-campaign.dto.ts
@@ -1,0 +1,4 @@
+import { PartialType } from '@nestjs/mapped-types';
+import { CreateCampaignDto } from './create-campaign.dto';
+
+export class UpdateCampaignDto extends PartialType(CreateCampaignDto) {}

--- a/src/campaign/entities/campaign.entity.ts
+++ b/src/campaign/entities/campaign.entity.ts
@@ -1,7 +1,8 @@
-import { Column, CreateDateColumn, ManyToOne, PrimaryGeneratedColumn, UpdateDateColumn } from "typeorm";
+import { Column, CreateDateColumn, Entity, ManyToOne, PrimaryGeneratedColumn, UpdateDateColumn } from "typeorm";
 import { campaignStatus } from "../dto/campaignStatus";
 import { User } from "src/user/entities/user.entity";
 
+@Entity()
 export class Campaign {
     @PrimaryGeneratedColumn()
     campaign_id: number
@@ -10,19 +11,19 @@ export class Campaign {
     campaign_title: string
 
     @Column()
-    cmapaign_description: string
+    campaign_description: string
 
-    @Column()
-    targetAmount: BigInt
+    @Column({ type: 'bigint' })
+    targetAmount: number;
 
-    @Column()
-    start_date: Date
+    @Column({ type: 'date' }) // Ensuring 'date' type is explicitly specified
+    start_date: Date;
 
-    @Column()
-    end_date: Date
+    @Column({ type: 'date' })
+    end_date: Date;
 
     @Column({ type: 'enum', enum: campaignStatus })
-    role: campaignStatus
+    status: campaignStatus
 
     @CreateDateColumn({ type: 'timestamp', default: () => 'CURRENT_TIMESTAMP' })
     created_at: Date;
@@ -31,6 +32,8 @@ export class Campaign {
     updated_at: Date;
 
 
-
+    //raltion with user table
+    @ManyToOne(() => User, (user) => user.campaign)
+    user: User
 
 }

--- a/src/campaign/entities/campaign.entity.ts
+++ b/src/campaign/entities/campaign.entity.ts
@@ -1,0 +1,36 @@
+import { Column, CreateDateColumn, ManyToOne, PrimaryGeneratedColumn, UpdateDateColumn } from "typeorm";
+import { campaignStatus } from "../dto/campaignStatus";
+import { User } from "src/user/entities/user.entity";
+
+export class Campaign {
+    @PrimaryGeneratedColumn()
+    campaign_id: number
+
+    @Column()
+    campaign_title: string
+
+    @Column()
+    cmapaign_description: string
+
+    @Column()
+    targetAmount: BigInt
+
+    @Column()
+    start_date: Date
+
+    @Column()
+    end_date: Date
+
+    @Column({ type: 'enum', enum: campaignStatus })
+    role: campaignStatus
+
+    @CreateDateColumn({ type: 'timestamp', default: () => 'CURRENT_TIMESTAMP' })
+    created_at: Date;
+
+    @UpdateDateColumn({ type: 'timestamp', default: () => 'CURRENT_TIMESTAMP', onUpdate: 'CURRENT_TIMESTAMP' })
+    updated_at: Date;
+
+
+
+
+}

--- a/src/user/entities/user.entity.ts
+++ b/src/user/entities/user.entity.ts
@@ -1,5 +1,6 @@
-import { Column, CreateDateColumn, Entity, PrimaryGeneratedColumn, UpdateDateColumn } from "typeorm";
+import { Column, CreateDateColumn, Entity, OneToMany, PrimaryGeneratedColumn, UpdateDateColumn } from "typeorm";
 import { userType } from "../dto/userRole";
+import { Campaign } from "src/campaign/entities/campaign.entity";
 
 @Entity()
 export class User {
@@ -30,5 +31,8 @@ export class User {
     @UpdateDateColumn({ type: 'timestamp', default: () => 'CURRENT_TIMESTAMP', onUpdate: 'CURRENT_TIMESTAMP' })
     updated_at: Date;
 
+    //relation to campaign table
+    @OneToMany(() => Campaign, (campaign) => campaign.user)
+    campaign: Campaign;
 
 }

--- a/src/user/user.module.ts
+++ b/src/user/user.module.ts
@@ -3,9 +3,10 @@ import { UserService } from './user.service';
 import { UserController } from './user.controller';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { User } from './entities/user.entity';
+import { Campaign } from 'src/campaign/entities/campaign.entity';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([User])],
+  imports: [TypeOrmModule.forFeature([User, Campaign])],
   controllers: [UserController],
   providers: [UserService],
   exports: [UserService]


### PR DESCRIPTION
# PR Title: feature/campaign: create campaign table with relations and CRUD operations

## Summary
This PR introduces the `Campaign` table along with the relationships between the `User` and `Campaign` entities. The following key updates are included:

- **Campaign Entity**: A new table has been created to store campaign details, including title, description, target amount, and campaign status.
- **User-Campaign Relationship**: The `User` and `Campaign` entities have been linked to establish a one-to-many relationship, allowing users to create and manage multiple campaigns.
- **CRUD Operations**: Full CRUD operations (Create, Read, Update, Delete) have been implemented for the `Campaign` entity. These operations allow users to manage campaigns, including creating, retrieving, updating, and deleting campaigns.

## Changes
- Created `Campaign` entity with fields: `campaign_title`, `campaign_description`, `targetAmount`, `start_date`, `end_date`, and `status`.
- Added `ManyToOne` relationship between `User` and `Campaign` entities to associate a user with multiple campaigns.
- Implemented complete CRUD operations for the `Campaign` entity:
  - **Create**: Allows the creation of new campaigns with user association.
  - **Read**: Fetch campaigns, including specific user campaigns.
  - **Update**: Update campaign details as needed.
  - **Delete**: Enable deletion of campaigns associated with users.

## Next Steps
- Further enhance API documentation for campaign-related endpoints.
- Optimize query performance for reading campaigns with large datasets.


